### PR TITLE
Including compression componenets in arrow build

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Installing Build Tools.
         run: brew install boost pkg-config
 
-      - name: Export CPATH for Mac Compiler
-        run: export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
-
       - name: Get Arrow repo
         uses: actions/checkout@v2
         with:

--- a/configure/build-arrow.sh
+++ b/configure/build-arrow.sh
@@ -6,6 +6,11 @@ else
   echo "CPATH Not found"
 fi
 
+echo "------------------------------"
+echo $OSTYPE
+echo "------------------------------"
+
+
 mkdir -p build/arrow
 cmake -S arrow/cpp/  -B build/arrow \
                 -DARROW_BUILD_SHARED=OFF \

--- a/configure/build-arrow.sh
+++ b/configure/build-arrow.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-echo $CPATH
+if [[ -z "${CPATH}" ]]; then
+  echo $CPATH
+else
+  echo "CPATH Not found"
+fi
+
 mkdir -p build/arrow
 cmake -S arrow/cpp/  -B build/arrow \
                 -DARROW_BUILD_SHARED=OFF \

--- a/configure/build-arrow.sh
+++ b/configure/build-arrow.sh
@@ -10,6 +10,10 @@ echo "------------------------------"
 echo $OSTYPE
 echo "------------------------------"
 
+if [ $OSTYPE = "darwin19" ] ; then
+  export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+fi
+
 
 mkdir -p build/arrow
 cmake -S arrow/cpp/  -B build/arrow \

--- a/configure/build-arrow.sh
+++ b/configure/build-arrow.sh
@@ -1,19 +1,8 @@
 #!/bin/bash
 
-if [[ -z "${CPATH}" ]]; then
-  echo $CPATH
-else
-  echo "CPATH Not found"
-fi
-
-echo "------------------------------"
-echo $OSTYPE
-echo "------------------------------"
-
 if [ $OSTYPE = "darwin19" ] ; then
   export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
 fi
-
 
 mkdir -p build/arrow
 cmake -S arrow/cpp/  -B build/arrow \

--- a/configure/build-arrow.sh
+++ b/configure/build-arrow.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ls -l 
+echo $CPATH
 mkdir -p build/arrow
 cmake -S arrow/cpp/  -B build/arrow \
                 -DARROW_BUILD_SHARED=OFF \


### PR DESCRIPTION
- Fixes #14  as the compression libraries are not included previously causing the executable to abort 
- Fixed Mac Build Action failing due to CPATH problem
- Cleanup commits